### PR TITLE
Adding JAVA_OPTS

### DIFF
--- a/root/etc/services.d/airsonic/run
+++ b/root/etc/services.d/airsonic/run
@@ -14,6 +14,7 @@ cd "${AIRSONIC_HOME}" || exit
 exec \
 	s6-setuidgid abc \
 	java -Dorg.eclipse.jetty.annotations.maxWait="${MAX_WAIT}" \
+	${JAVA_OPTS} \
 	-Dairsonic.home="${AIRSONIC_SETTINGS}" \
 	-Dairsonic.defaultMusicFolder=/music \
 	-Dairsonic.defaultPodcastFolder=/podcasts \


### PR DESCRIPTION
This fixed #8 

It didn't fix the underlying cause that got me to use the setting (I'm getting mixed content warnings when going through Traefik), but my JAVA_OPTS are honored now.